### PR TITLE
Configure HF MCP and add prompt profiles

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,6 +223,7 @@ The `prompts` directory contains various Markdown files that control agent behav
 2. Copy and modify needed files from `prompts/default/`
 3. Agent Zero will merge your custom files with the default ones
 4. Select your custom prompts in the Settings page (Agent Config section)
+5. Example profiles included in the repository are `vibecoding`, `videomaker` and `nsfw` which showcase specialized prompt sets
 
 #### Dynamic Behavior System
 - **Behavior Adjustment**: 

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -122,3 +122,20 @@ Once configured, successfully installed (if applicable, e.g., for `npx` based se
 *   **Execution Flow**: Agent Zero's `process_tools` method (with logic in `python/helpers/mcp_handler.py`) prioritizes looking up the tool name in the `MCPConfig`. If found, the execution is delegated to the corresponding MCP server. If not found as an MCP tool, it then attempts to find a local/built-in tool with that name.
 
 This setup provides a flexible way to extend Agent Zero's capabilities by integrating with various external tool providers without modifying its core codebase. 
+## Example: Hugging Face MCP
+
+To integrate tools from the public Hugging Face MCP server, add an entry similar to the following in your settings:
+
+```json
+{
+    "name": "hf-mcp",
+    "description": "HuggingFace MCP tools",
+    "url": "https://huggingface.co/mcp",
+    "headers": { "Authorization": "Bearer ${HF_MCP_TOKEN}" },
+    "init_timeout": 10,
+    "tool_timeout": 200
+}
+```
+
+Store your access token in the `HF_MCP_TOKEN` variable of your `.env` file.
+

--- a/example.env
+++ b/example.env
@@ -12,6 +12,8 @@ OPENAI_AZURE_ENDPOINT=
 OPENAI_API_VERSION=
 
 HF_TOKEN=
+# Optional Hugging Face token for MCP server
+HF_MCP_TOKEN=
 
 
 WEB_UI_PORT=50001

--- a/prompts/nsfw/_context.md
+++ b/prompts/nsfw/_context.md
@@ -1,0 +1,3 @@
+# Adult
+- agent specialized in adult and NSFW content workflows
+- uses appropriate MCP tools with no restrictions

--- a/prompts/vibecoding/_context.md
+++ b/prompts/vibecoding/_context.md
@@ -1,0 +1,3 @@
+# Vibecoding
+- agent specialized in creative coding and workflow automation
+- helps prototype projects quickly

--- a/prompts/videomaker/_context.md
+++ b/prompts/videomaker/_context.md
@@ -1,0 +1,3 @@
+# Videomaker
+- agent specialized in video generation and editing
+- integrates face-swapping and other multimedia MCP tools


### PR DESCRIPTION
## Summary
- document how to connect to the HuggingFace MCP server
- note built-in prompt profiles in the architecture doc
- add optional `HF_MCP_TOKEN` env variable
- add `vibecoding`, `videomaker`, and `nsfw` prompt profiles

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'attr')*

------
https://chatgpt.com/codex/tasks/task_b_685f1779b3b48322a0ddbbacaaf08736