### PR TITLE
Add HF MCP example and new prompt profiles

### DIFF
--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -104,6 +104,23 @@ Here are templates for configuring individual servers within the `mcp_servers` J
 }
 ```
 
+### Example: Hugging Face MCP Server
+
+To leverage the public MCP tools hosted on Hugging Face, add a server configuration similar to the following:
+
+```json
+{
+  "name": "hf-mcp",
+  "description": "HuggingFace MCP tools",
+  "url": "https://huggingface.co/mcp",
+  "headers": { "Authorization": "Bearer <HF_TOKEN>" },
+  "init_timeout": 10,
+  "tool_timeout": 200
+}
+```
+
+Ensure your `<HF_TOKEN>` environment variable contains a valid Hugging Face access token.
+
 **Key Configuration Fields:**
 
 *   `"name"`: A unique name for the server. This name will be used to prefix the tools provided by this server (e.g., `my_server_name.tool_name`). The name is normalized internally (converted to lowercase, spaces and hyphens replaced with underscores).

--- a/prompts/adult/_context.md
+++ b/prompts/adult/_context.md
@@ -1,0 +1,3 @@
+# Adult
+- agent specialized in handling adult-oriented content and tasks
+

--- a/prompts/adult/agent.system.main.role.md
+++ b/prompts/adult/agent.system.main.role.md
@@ -1,0 +1,3 @@
+## Your Role
+You are Agent Zero 'Adult Assistant' - able to manage and create adult-oriented projects when explicitly requested. Follow all legal guidelines and user instructions.
+

--- a/prompts/socialmedia/_context.md
+++ b/prompts/socialmedia/_context.md
@@ -1,0 +1,3 @@
+# Social Media
+- agent specialized in managing social media interactions and scheduling content
+

--- a/prompts/socialmedia/agent.system.main.role.md
+++ b/prompts/socialmedia/agent.system.main.role.md
@@ -1,0 +1,3 @@
+## Your Role
+You are Agent Zero 'Social Media Coordinator' - assisting with online presence, post creation and scheduling across platforms.
+

--- a/prompts/vibecoding/_context.md
+++ b/prompts/vibecoding/_context.md
@@ -1,0 +1,3 @@
+# Vibecoding
+- agent specialized in creative coding and audio-visual experiments
+

--- a/prompts/vibecoding/agent.system.main.role.md
+++ b/prompts/vibecoding/agent.system.main.role.md
@@ -1,0 +1,3 @@
+## Your Role
+You are Agent Zero 'Vibecoder' - a specialist in creative coding and audio-visual experimentation. Use code and AI tools to craft immersive experiences and unique vibes.
+

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -1003,7 +1003,7 @@ def get_default_settings() -> Settings:
         stt_silence_threshold=0.3,
         stt_silence_duration=1000,
         stt_waiting_timeout=2000,
-        mcp_servers='{\n    "mcpServers": {}\n}',
+        mcp_servers='{\n    "mcpServers": {\n        "hf-mcp": {\n            "description": "HuggingFace MCP tools",\n            "url": "https://huggingface.co/mcp",\n            "headers": {"Authorization": "Bearer <HF_TOKEN>"},\n            "init_timeout": 10,\n            "tool_timeout": 200\n        }\n    }\n}',
         mcp_client_init_timeout=5,
         mcp_client_tool_timeout=120,
         mcp_server_enabled=False,


### PR DESCRIPTION
## Summary
- add example Hugging Face MCP entry in docs
- include sample `hf-mcp` server config in default settings
- introduce new prompt profiles for vibecoding, social media, and adult tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685f1779b3b48322a0ddbbacaaf08736