### PR TITLE
Add script for HuggingFace MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ docker run -p 50001:80 frdel/agent-zero-run
 # Visit http://localhost:50001 to start
 ```
 
+If you want to use the public HuggingFace MCP tools, set the `HF_TOKEN` environment variable and run:
+
+```bash
+python scripts/setup_hf_mcp.py
+```
+
 ## 🐳 Fully Dockerized, with Speech-to-Text and TTS
 
 ![Settings](docs/res/settings-page-ui.png)

--- a/scripts/setup_hf_mcp.py
+++ b/scripts/setup_hf_mcp.py
@@ -1,0 +1,75 @@
+import os
+import json
+from pathlib import Path
+
+HF_SERVER_NAME = "hf-mcp"
+HF_SERVER_CONFIG = {
+    "name": HF_SERVER_NAME,
+    "description": "HuggingFace MCP tools",
+    "url": "https://huggingface.co/mcp",
+    # headers will be added dynamically
+    "init_timeout": 10,
+    "tool_timeout": 200,
+}
+
+
+def load_settings(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def save_settings(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=4))
+
+
+def parse_servers(value: str):
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except Exception:
+        return []
+    if isinstance(parsed, dict):
+        # legacy object style
+        if "mcpServers" in parsed and isinstance(parsed["mcpServers"], dict):
+            return list(parsed["mcpServers"].values())
+        else:
+            return [parsed]
+    if isinstance(parsed, list):
+        return parsed
+    return []
+
+
+def main():
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        raise SystemExit("HF_TOKEN environment variable not set")
+
+    settings_file = Path("tmp/settings.json")
+    settings = load_settings(settings_file)
+
+    servers = parse_servers(settings.get("mcp_servers", ""))
+
+    HF_SERVER_CONFIG["headers"] = {"Authorization": f"Bearer {token}"}
+
+    updated = False
+    for i, srv in enumerate(servers):
+        if srv.get("name") == HF_SERVER_NAME:
+            servers[i] = HF_SERVER_CONFIG
+            updated = True
+            break
+    if not updated:
+        servers.append(HF_SERVER_CONFIG)
+
+    settings["mcp_servers"] = json.dumps(servers)
+    save_settings(settings_file, settings)
+    print(f"Saved HuggingFace MCP server config to {settings_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- script to add/update HuggingFace MCP entry in `tmp/settings.json`
- mention the script in Quick Start instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'attr')*
- `pip install attrs pytest` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6872f9cdfa9c8322af8ef2b1dff6ab11